### PR TITLE
LCL: corrects identifiant field name

### DIFF
--- a/modules/lcl/pages.py
+++ b/modules/lcl/pages.py
@@ -118,7 +118,7 @@ class LoginPage(BasePage):
             self.browser['agenceId'] = agency.encode('utf-8')
             self.browser['compteId'] = login.encode('utf-8')
         else:
-            self.browser['identifiant'] = login.encode('utf-8')
+            self.browser['identifiantIdForm'] = login.encode('utf-8')
         self.browser['postClavierXor'] = base64.b64encode(self.myXOR(password,seed))
         try:
             self.browser.submit(nologin=True)


### PR DESCRIPTION
Hi,

since today, november 7th 2013, the only way to login on LCL backend is using the « identifier » without agency code.
But it seems that the name of the input also changed.

I tested with indentifiantIdForm (after reading the LCL’s auth page source code), and it worked for me since then.

Best regards !
Hugues.
